### PR TITLE
Add support for source and target tracks (to promote from/to)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # promote-play-beta-action
-Promote the latest open testing release to production on Google Play
+Promote the latest open testing release from one track to another on Google Play.
 
 ## Inputs
 
@@ -21,8 +21,8 @@ Portion of users who should get the staged version of the app. Accepts values be
 
 ### `from-track`
 
-The source track to promote from. If not supplied, `beta` is used.
+The source track to promote from. Defaults to beta.
 
 ### `to-track`
 
-The target track to promote to. If not supplied, `production` is used.
+The target track to promote to. Defaults to production.

--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@ In-app update priority of the release. All newly added APKs in the release will 
 ### `user-fraction`
 
 Portion of users who should get the staged version of the app. Accepts values between 0.0 and 1.0 (exclusive-exclusive).
+
+### `from-track`
+
+The source track to promote from. If not supplied, `beta` is used.
+
+### `to-track`
+
+The target track to promote to. If not supplied, `production` is used.

--- a/action.yml
+++ b/action.yml
@@ -19,10 +19,12 @@ inputs:
     description: "Portion of users who should get the staged version of the app. Accepts values between 0.0 and 1.0 (exclusive-exclusive)"
     required: false
   from-track:
-    description: "The source track to promote from. If not supplied, `beta` is used."
+    description: "The source track to promote from. Defaults to beta."
+    default: "beta"
     required: false
   to-track:
-    description: "The target track to promote to. If not supplied, `production` is used."
+    description: "The target track to promote to. Defaults to production."
+    default: "production"
     required: false
 runs:
   using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,12 @@ inputs:
   user-fraction:
     description: "Portion of users who should get the staged version of the app. Accepts values between 0.0 and 1.0 (exclusive-exclusive)"
     required: false
+  from-track:
+    description: "The source track to promote from. If not supplied, `beta` is used."
+    required: false
+  to-track:
+    description: "The target track to promote to. If not supplied, `production` is used."
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,8 @@ inputs:
     default: '0'
     required: false
   user-fraction:
-    description: "Portion of users who should get the staged version of the app. Accepts values between 0.0 and 1.0 (exclusive-exclusive)"
+    description: "Portion of users who should get the staged version of the app. Accepts values between 0.0 and 1.0 (exclusive-inclusive). Defaults to 1.0"
+    default: 1.0
     required: false
   from-track:
     description: "The source track to promote from. Defaults to beta."

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "promote-play-beta-action",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/src/promote-play-release.js
+++ b/src/promote-play-release.js
@@ -43,7 +43,7 @@ export async function run() {
     });
 
     // Get the current source track, apply userFraction and inAppUpdatePriority to the release
-    const toTrackReleases = mapSourceToTargetTrack(authClient, appEdit.data.id, packageName, fromTrack);
+    const toTrackReleases = mapSourceToTargetTrack(publisher, authClient, appEdit.data.id, packageName, fromTrack);
 
     // Patch source track to target
     info(`Switching ${fromTrack} release to ${toTrack}, fraction ${userFraction} priority ${inAppUpdatePriority}`);
@@ -100,7 +100,7 @@ async function storeServiceAccountJson(rawJson) {
   exportVariable("GOOGLE_APPLICATION_CREDENTIALS", serviceAccountFile);
 }
 
-async function mapSourceToTargetTrack(authClient, editId, packageName, sourceTrackName) {
+async function mapSourceToTargetTrack(publisher, authClient, editId, packageName, sourceTrackName) {
   info(`Getting current ${sourceTrackName} info`);
   const sourceTrack = await publisher.edits.tracks.get({
     auth: authClient,

--- a/src/promote-play-release.js
+++ b/src/promote-play-release.js
@@ -1,6 +1,6 @@
 import { getInput, setFailed, exportVariable, debug, info } from '@actions/core';
 import { google } from 'googleapis';
-import { writeFileSync, unlinkSync, realpathSync } from 'fs';
+import { unlinkSync, promises as fspromises } from 'fs';
 
 let serviceAccountFile = "./serviceAccountJson.json";
 
@@ -27,7 +27,7 @@ export async function run() {
     }
 
     // Write service account JSON to file, then set the proper env variable so auth can find it.
-    storeServiceAccountJson(rawServiceAccountJson);
+    await storeServiceAccountJson(rawServiceAccountJson);
 
     // Get publisher
     const publisher = google.androidpublisher('v3');
@@ -92,11 +92,11 @@ async function getAuthClient() {
 
 async function storeServiceAccountJson(rawJson) {
   debug('Saving service account JSON for temporary use');
-  writeFileSync(serviceAccountFile, rawJson, {
+  await fspromises.writeFile(serviceAccountFile, rawJson, {
     encoding: 'utf8'
   });
 
-  serviceAccountFile = realpathSync(serviceAccountFile);
+  serviceAccountFile = await fspromises.realpath(serviceAccountFile);
   exportVariable("GOOGLE_APPLICATION_CREDENTIALS", serviceAccountFile);
 }
 

--- a/src/promote-play-release.js
+++ b/src/promote-play-release.js
@@ -11,8 +11,8 @@ export async function run() {
     const rawServiceAccountJson = getInput('service-account-json-raw', { required: true });
     const inAppUpdatePriorityInput = getInput('inapp-update-priority');
     const userFractionInput = getInput('user-fraction');
-    const fromTrack = getInput('from-track') ?? 'beta';
-    const toTrack = getInput('to-track') ?? 'production';
+    const fromTrack = getInput('from-track');
+    const toTrack = getInput('to-track');
     
     // Convert inputs to the correct types
     let userFraction;

--- a/src/promote-play-release.js
+++ b/src/promote-play-release.js
@@ -1,8 +1,8 @@
 import { getInput, setFailed, exportVariable, debug, info } from '@actions/core';
 import { google } from 'googleapis';
-import { writeFileSync, unlinkSync } from 'fs';
+import { writeFileSync, unlinkSync, realpathSync } from 'fs';
 
-const serviceAccountFile = "./serviceAccountJson.json";
+let serviceAccountFile = "./serviceAccountJson.json";
 
 export async function run() {
   try {
@@ -95,6 +95,8 @@ async function storeServiceAccountJson(rawJson) {
   writeFileSync(serviceAccountFile, rawJson, {
     encoding: 'utf8'
   });
+
+  serviceAccountFile = realpathSync(serviceAccountFile);
   exportVariable("GOOGLE_APPLICATION_CREDENTIALS", serviceAccountFile);
 }
 

--- a/src/promote-play-release.js
+++ b/src/promote-play-release.js
@@ -33,7 +33,7 @@ export async function run() {
     const publisher = google.androidpublisher('v3');
 
     // Authenticate
-    const authClient = getAuthClient();
+    const authClient = await getAuthClient();
 
     // Create app edit
     info('Creating a new edit');


### PR DESCRIPTION
Note: I have not tested this yet, just wanted to get it out there for feedback first in case you'd like me to rework it.

<hr/>

When I release my app, I first move from `alpha` to `beta`, then `beta` to `production`.

These changes add support for arbitrary track names, so I can [hopefully!] use this action to achieve that flow.

The inputs are not required for backwards compatibility - as in, the old hardcoded `beta`->`production` promotion remains the default.